### PR TITLE
Given texts are rendered conditionally now.

### DIFF
--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -26,16 +26,20 @@ const BaseToast = (props) => {
 
       <View style={styles.contentContainer}>
         <View style={styles.body}>
-          <View>
-            <Text style={styles.text1} numberOfLines={1}>
-              {text1}
-            </Text>
-          </View>
-          <View>
-            <Text style={styles.text2} numberOfLines={2}>
-              {text2}
-            </Text>
-          </View>
+          {text1 !== undefined &&
+            <View>
+              <Text style={styles.text1} numberOfLines={1}>
+                {text1}
+              </Text>
+            </View>
+          }
+          {text2 !== undefined &&
+            <View>
+              <Text style={styles.text2} numberOfLines={2}>
+                {text2}
+              </Text>
+            </View>
+          }
         </View>
       </View>
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,8 @@ const getInitialState = (props) => {
     autoHide: true,
 
     // content
-    text1: '',
-    text2: '',
+    text1: undefined,
+    text2: undefined,
 
     onShow,
     onHide


### PR DESCRIPTION
Updated default values of text1 & text2 to `undefined`. 

The omitted texts won't take space. Caller may optionally pass empty string if still needs related text's layout.