### PR TITLE
:bug: Fix reference to static variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,23 +56,23 @@ class Toast extends Component {
   static _ref = null;
 
   static setRef(ref = {}) {
-    this._ref = ref;
+    Toast._ref = ref;
   }
 
   static getRef() {
-    return this._ref;
+    return Toast._ref;
   }
 
   static clearRef() {
-    this._ref = null;
+    Toast._ref = null;
   }
 
   static show(options = {}) {
-    this._ref.show(options);
+    Toast._ref.show(options);
   }
 
   static hide() {
-    this._ref.hide();
+    Toast._ref.hide();
   }
 
   constructor(props) {


### PR DESCRIPTION
https://github.com/calintamas/react-native-toast-message/issues/89

This library doesn't work when installed via npm install because class is referenced in a wrong way from static functions in JavaScript sense.