### PR TITLE
Allow style prop to style the base component.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const getInitialState = (props) => {
     bottomOffset = 40,
     visibilityTime = 4000,
     onShow,
-    onHide,
+    onHide
   } = props;
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,7 @@ class Toast extends Component {
     return (
       <Animated.View
         onLayout={this.onLayout}
-        style={[...baseStyle,this.props.baseStyle || {}]}
+        style={[...baseStyle,this.props.style || {}]}
         {...this.panResponder.panHandlers}>
         {this.renderContent(this.props)}
       </Animated.View>

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const getInitialState = (props) => {
     bottomOffset = 40,
     visibilityTime = 4000,
     onShow,
-    onHide
+    onHide,
   } = props;
 
   return {
@@ -313,7 +313,7 @@ class Toast extends Component {
     return (
       <Animated.View
         onLayout={this.onLayout}
-        style={baseStyle}
+        style={[...baseStyle,this.props.baseStyle || {}]}
         {...this.panResponder.panHandlers}>
         {this.renderContent(this.props)}
       </Animated.View>


### PR DESCRIPTION
Couldn't get this library to work with @react-navigation/native and react-native-screens. Not sure which library specifically caused the issue, but allowing configuration the base component's style fixed the issue - just added a zIndex 10 and it worked.

There might be a neater way to allow more configuration, like accepting a bunch of props in the base `Toast` component that could be passed to the `Animated.View`, but this seems a fine enough place to start.

Check #92, #85 