### PR TITLE
Reset customProps every time show is called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ class Toast extends Component {
       height: prevState.height,
       inProgress: true,
       ...options,
-      ...(options?.props ? { customProps: options.props } : {})
+      ...(options?.props ? { customProps: options.props } : { customProps: {} })
     }));
     await this.animateShow();
     await this._setState((prevState) => ({


### PR DESCRIPTION
We need to reset `customProps` state every time `show` is called. In current code if `props` is not presented when calling `show`, `customProps` will keep the value last time called.