### PR TITLE
Bugfix/number of line props

### DIFF
--- a/src/__tests__/Toast.test.js
+++ b/src/__tests__/Toast.test.js
@@ -196,6 +196,66 @@ describe('test Toast behavior', () => {
     });
   });
 
+  describe('textXNumberOfLines props', async () => {
+    it('accepts text1NumberOfLines prop', async () => {
+      const { ref, getText1 } = setup();
+
+      await act(async () => {
+        await ref.current.show({
+          type: 'info',
+          text1: 'test',
+          text1NumberOfLines: 5
+        });
+      });
+
+      await waitFor(() => getText1());
+
+      const { numberOfLines } = getText1().props;
+
+      expect(numberOfLines).toBe(5);
+    });
+
+    it('accepts text2NumberOfLines prop', async () => {
+      const { ref, getText2 } = setup();
+
+      await act(async () => {
+        await ref.current.show({
+          type: 'info',
+          text1: 'test',
+          text2: 'test',
+          text2NumberOfLines: 4
+        });
+      });
+
+      await waitFor(() => getText2());
+
+      const { numberOfLines } = getText2().props;
+
+      expect(numberOfLines).toBe(4);
+    });
+
+    it('default number of lines should be 1 and 2', async () => {
+      const { ref, getText1, getText2 } = setup();
+
+      await act(async () => {
+        await ref.current.show({
+          type: 'info',
+          text1: 'test',
+          text2: 'test'
+        });
+      });
+
+      await waitFor(() => getText1());
+      await waitFor(() => getText2());
+
+      const { numberOfLines: text1Lines } = getText1().props;
+      const { numberOfLines: text2Lines } = getText2().props;
+
+      expect(text1Lines).toBe(1);
+      expect(text2Lines).toBe(2);
+    });
+  });
+
   describe('test props', () => {
     it('shows Toast from custom config', async () => {
       const testID = 'testView';

--- a/src/index.js
+++ b/src/index.js
@@ -333,7 +333,9 @@ class Toast extends Component {
           'text2',
           'hide',
           'show',
-          'onPress'
+          'onPress',
+          'text1NumberOfLines',
+          'text2NumberOfLines'
         ]
       }),
       props: { ...customProps },
@@ -401,7 +403,9 @@ Toast.propTypes = {
   autoHide: PropTypes.bool,
   height: PropTypes.number,
   position: PropTypes.oneOf(['top', 'bottom']),
-  type: PropTypes.string
+  type: PropTypes.string,
+  text1NumberOfLines: PropTypes.number,
+  text2NumberOfLines: PropTypes.number
 };
 
 Toast.defaultProps = {
@@ -414,7 +418,9 @@ Toast.defaultProps = {
   autoHide: true,
   height: 60,
   position: 'top',
-  type: 'success'
+  type: 'success',
+  text1NumberOfLines: 1,
+  text2NumberOfLines: 2
 };
 
 export default Toast;


### PR DESCRIPTION
Pull request for [textXNumberOfLines](https://github.com/calintamas/react-native-toast-message/pull/152) was not passing the props text1NumberOfLines and text2NumberOfLines down to the child components. I've added this and written some tests