### PR TITLE
props to default components

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ const props = {
 
 > Default `Animated.View` styles can be found in [styles.js](https://github.com/calintamas/react-native-toast-message/blob/master/src/styles.js#L4). They can be extended using the `style` prop.
 
+## Customize show
+You can Customize the default components by overwrite BaseToast props
+```js
+Toast.show({
+    type:'error',
+    text1: 'Error',
+    text2: 'some error msg',
+    props:{
+        text1Style:{
+            fontSize: 18,
+        },
+        text2Style:{
+            fontSize: 14,
+        }
+    }
+});
+```
+
+### 
+
+
 ## Customize layout
 
 If you want to add custom types - or overwrite the existing ones - you can add a `config` prop when rendering the `Toast` in your app `root`. 
@@ -124,7 +145,7 @@ const toastConfig = {
     overwrite 'success' type, 
     modifying the existing `BaseToast` component
   */
-  success: ({ text1, props, ...rest }) => (
+  success: ({ text1, uuid, ...rest }) => (
     <BaseToast
       {...rest}
       style={{ borderLeftColor: 'pink' }}
@@ -134,7 +155,7 @@ const toastConfig = {
         fontWeight: '400'
       }}
       text1={text1}
-      text2={props.uuid}
+      text2={uuid}
     />
   ),
   

--- a/src/components/error.js
+++ b/src/components/error.js
@@ -7,9 +7,9 @@ import colors from '../colors';
 function ErrorToast(props) {
   return (
     <BaseToast
-      {...props}
       style={{ borderLeftColor: colors.blazeOrange }}
       leadingIcon={icons.error}
+      {...props}
     />
   );
 }

--- a/src/components/info.js
+++ b/src/components/info.js
@@ -7,9 +7,9 @@ import colors from '../colors';
 function InfoToast(props) {
   return (
     <BaseToast
-      {...props}
       style={{ borderLeftColor: colors.lightSkyBlue }}
       leadingIcon={icons.info}
+      {...props}
     />
   );
 }

--- a/src/components/success.js
+++ b/src/components/success.js
@@ -7,9 +7,9 @@ import colors from '../colors';
 function SuccessToast(props) {
   return (
     <BaseToast
-      {...props}
       style={{ borderLeftColor: colors.mantis }}
       leadingIcon={icons.success}
+      {...props}
     />
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,7 @@ class Toast extends Component {
           'onPress'
         ]
       }),
-      props: { ...customProps },
+      ...customProps,
       hide: this.hide,
       show: this.show
     });


### PR DESCRIPTION
At first this is my first pull request ever so I apologize if my writing is bad.
Anyway what I did is that I changed the customProps so I can overwrite default components props, cuz I wanted to use the default error, info and success but I wanted to change the font size and sometimes small changes in the components instead of just rewriting it in config, and u still can pass an customProps to customType ( I updated the example in the readme )
I tested it all and I updated the readme 