### PR TITLE
update Readme example for success type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import Toast from 'react-native-toast-message';
 function SomeComponent() {
   React.useEffect(() => {
     Toast.show({
+      type:  'success',
       text1: 'Hello',
       text2: 'This is some something 👋'
     });


### PR DESCRIPTION
the show-function-object used in the example appears to require a "type" property. At least the Typescript types don't show it as optional. So my intellisense immediately complained when using the example. Adding a type, like 'success' immediately fixed the error. So I figured we could update the example