### PR TITLE
fix: toasts shouldn't be stuck when using keyboard consequently

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,23 +145,23 @@ class Toast extends Component {
   }
 
   keyboardDidShow = (e) => {
-    const { isVisible, position } = this.state;
+    const { isVisible, position, inProgress } = this.state;
     this.setState({
       keyboardHeight: e.endCoordinates.height,
       keyboardVisible: true
     });
 
-    if (isVisible && position === 'bottom') {
+    if (isVisible && position === 'bottom' && !inProgress) {
       this.animate({ toValue: 2 });
     }
   };
 
   keyboardDidHide = () => {
-    const { isVisible, position } = this.state;
+    const { isVisible, position, inProgress } = this.state;
     this.setState({
       keyboardVisible: false
     });
-    if (isVisible && position === 'bottom') {
+    if (isVisible && position === 'bottom' && !inProgress) {
       this.animate({ toValue: 1 });
     }
   };


### PR DESCRIPTION
Hi,

When using the keyboard of a device consequently tapping on an input field, then closing the keyboard, then tapping on the input again - all while a toast is visible and shown on the screen (and avoiding the keyboard, precisely sliding above it to be visible) is creating a situation where after two rounds of tapping, closing and opening the keyboard again, the toast that is present would get stuck on the screen and not **autoHide** as it should.
I made a fix that I tested and I think mitigates the issue I described.

Regards,
A