### PR TITLE
export default toast to reuse them with custom props.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ const props = {
 
 If you want to add custom types - or overwrite the existing ones - you can add a `config` prop when rendering the `Toast` in your app `root`. 
 
-You can either use the default `BaseToast` style and adjust its layout, or create Toast layouts from scratch.
+You can either use the default `BaseToast` style and adjust its layout, or create Toast layouts from scratch or reuse the default layout
 
 ```js
 // App.jsx
-import Toast, { BaseToast }  from 'react-native-toast-message';
+import Toast, { BaseToast, ErrorToast }  from 'react-native-toast-message';
 
 const toastConfig = {
   /* 
@@ -138,6 +138,20 @@ const toastConfig = {
       text2={props.uuid}
     />
   ),
+  
+  /*
+    Reuse the default toast with custom props.
+  */
+  error: ({ hide, ...rest }) => (
+        <ErrorToast {...rest} onTrailingIconPress={hide} 
+            text1Style={{
+                fontSize: 17
+            }}
+            text2Style={{
+                fontSize: 15
+            }}
+        />
+    ),
   
   /* 
     or create a completely new type - `my_custom_type`,

--- a/README.md
+++ b/README.md
@@ -139,20 +139,20 @@ const toastConfig = {
     />
   ),
   
-  /*
-    Reuse the default toast with custom props.
+   /*
+    Reuse the default ErrorToast toast component
   */
-  error: ({ hide, ...rest }) => (
-        <ErrorToast {...rest} onTrailingIconPress={hide} 
-            text1Style={{
-                fontSize: 17
-            }}
-            text2Style={{
-                fontSize: 15
-            }}
-        />
-    ),
-  
+  error: (props) => (
+    <ErrorToast 
+      {...props}
+      text1Style={{
+        fontSize: 17
+      }}
+      text2Style={{
+        fontSize: 15
+      }}
+    />
+  ),
   /* 
     or create a completely new type - `my_custom_type`,
     building the layout from scratch

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const props = {
 
 If you want to add custom types - or overwrite the existing ones - you can add a `config` prop when rendering the `Toast` in your app `root`. 
 
-You can either use the default `BaseToast` style and adjust its layout, or create Toast layouts from scratch or reuse the default layout
+You can either use any of the default `BaseToast`, `SuccessToast`, `ErrorToast` or `InfoToast` components and adjust their layout, or create Toast layouts from scratch.
 
 ```js
 // App.jsx

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,9 @@ declare module 'react-native-toast-message' {
     text2NumberOfLines: number,
   }
   export const BaseToast: React.FC<BaseToastProps>
+  export const SuccessToast: React.FC<BaseToastProps>
+  export const ErrorToast: React.FC<BaseToastProps>
+  export const InfoToast: React.FC<BaseToastProps>
 
   export interface ToastProps {
     ref: (ref: any) => any;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 import Toast from './src';
 
 export { default as BaseToast } from './src/components/base';
+export { default as SuccessToast } from './src/components/success';
+export { default as ErrorToast } from './src/components/error';
+export { default as InfoToast } from './src/components/info';
 export default Toast;


### PR DESCRIPTION
Hello,
I want to use the default toast layout but with small changes so instead of re-create the layout I want to use the old one and just override the props.