### PR TITLE
Trigger keyboard hide animation when show animation is in progress 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,11 +157,11 @@ class Toast extends Component {
   };
 
   keyboardDidHide = () => {
-    const { isVisible, position } = this.state;
+    const { isVisible, position, inProgress } = this.state;
     this.setState({
       keyboardVisible: false
     });
-    if (isVisible && position === 'bottom') {
+    if ((isVisible || (!isVisible && inProgress)) && position === 'bottom') {
       this.animate({ toValue: 1 });
     }
   };


### PR DESCRIPTION
Keyboard animation is not triggered in case the dismiss Keyboard action is triggered and a toast is showing at the same time, this way we could trigger the animation with the new position even if the toast is in progress and was previously hidden - aka will be shown