### PR TITLE
Use stricter TS type for the 'type' property when calling 'show'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ declare module 'react-native-toast-message' {
   }
 
   export interface ToastShowOptions {
-    type: string,
+    type: 'success' | 'error' | 'info',
     position?: ToastPosition,
     text1?: string,
     text2?: string,


### PR DESCRIPTION
With this change, users will get a TypeScript error when setting `type` to an invalid value, and TypeScript developer tools will also provide helpful auto-complete for this property.