### PR TITLE
feat: use refs being set to determine which Toast instance to use

### DIFF
--- a/docs/modal-usage.md
+++ b/docs/modal-usage.md
@@ -29,25 +29,30 @@ This means **you need a new instance** of `<Toast />` rendered inside your `Moda
 
 > Same behavior when using [react-native-modal](https://github.com/react-native-modal/react-native-modal) or a [NativeStackNavigator](https://reactnavigation.org/docs/native-stack-navigator#presentation) with `presentation: 'modal'`
 
-The `ref` will still be tracked automatically, but there's one more thing that needs to be done for this to work properly. **You need to specify how _nested_ is your new `<Toast />` instance**: this is done via the `nestingLevel` prop.
-
-By default `nestingLevel` is `0` - this is the _root level_ (the `<Toast />` that is rendered in your App's entry point).
-
-If you go a level "higher", inside a Modal, you get _level 1_ (a Modal is on top of your root, so you can think of it as being "higher" than your root). If you have another modal inside the previous Modal, you get _level 2_, and so on
+The `ref` will still be tracked automatically. Whichever `<Toast />` instance last had its `ref` set will be used when showing/hiding.
 
 ```js
 <>
+
+  {** This `Toast` will show when neither the native stack screen nor `Modal` are presented. *}
   <Toast />
-  <Modal>
-    <Toast nestingLevel={1} />
+
+  <NativeStackNavigator.Screen>
+
+    {** This `Toast` will show when the `NativeStackNavigator.Screen` is visible, but the `Modal` is NOT visible. *}
+    <Toast />
+
     <Modal>
-      <Toast nestingLevel={2} />
+
+      {** This `Toast` will show when both the `NativeStackNavigator.Screen` and the `Modal` are visible. *}
+      <Toast />
+
     </Modal>
-  </Modal>
+  </NativeStackNavigator.Screen>
 </>
 ```
 
-So, when you have a `Modal` (1 level nesting), the implementation looks like this:
+So, when you have a `Modal`, the implementation looks like this:
 
 ```diff
 // App.jsx
@@ -62,11 +67,11 @@ export function App(props) {
       {/* ... */}
       <Toast />
       <Modal visible={isModalVisible}>
-+        <Toast nestingLevel={1} />
++        <Toast />
       </Modal>
     </>
   );
 }
 ```
 
-Everything else works as usual, you can show and hide Toasts using the imperative API: `Toast.show()` or `Toast.hide()`. When the `Modal` is visible, the `ref` from inside the `Modal` will be used, otherwise the one outside.
+Everything else works as usual; you can show and hide Toasts using the imperative API: `Toast.show()` or `Toast.hide()`. When the `Modal` is visible, the `ref` from inside the `Modal` will be used, otherwise the one outside.

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -16,10 +16,11 @@ const ToastRoot = React.forwardRef((props: ToastProps, ref) => {
     defaultOptions
   });
 
-  React.useImperativeHandle(ref, () => ({
+  // This must use useCallback to ensure the ref doesn't get set to null and then a new ref every render.
+  React.useImperativeHandle(ref, React.useCallback(() => ({
     show,
     hide
-  }));
+  }), [hide, show]));
 
   return (
     <ToastUI
@@ -54,14 +55,10 @@ export function Toast(props: ToastProps) {
   return (
     <LoggerProvider enableLogs={false}>
       <ToastRoot
-        ref={(ref: ToastRef | null) => {
+        // This must use `useCallback` to ensure the ref doesn't get set to null and then a new ref every render. Failure to do so will cause whichever Toast *renders or re-renders* last to be the instance that is used, rather than being the Toast that was *mounted* last.
+        ref={React.useCallback((ref: ToastRef | null) => {
           // Since we know there's a ref, we'll update `refs` to use it.
           if (ref) {
-            // if by chance the ref's object changes, make sure to remove the previous ref object.
-            if (toastRef.current && ref !== toastRef.current) {
-              removeOldRef(toastRef.current);
-            }
-
             // store the ref in this toast instance to be able to remove it from the array later when the ref becomes null.
             toastRef.current = ref;
 
@@ -73,7 +70,7 @@ export function Toast(props: ToastProps) {
             // remove the this toast's ref, wherever it is in the array.
             removeOldRef(toastRef.current);
           }
-        }}
+        }, [])}
         {...props}
       />
     </LoggerProvider>

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -37,18 +37,44 @@ type ToastRefObj = {
   current: ToastRef | null;
 };
 
-const refs: ToastRefObj[] = [];
+let refs: ToastRefObj[] = [];
 
-export function Toast({ nestingLevel = 0, ...rest }: ToastProps) {
+/**
+ * Removes the passed in ref from the file-level refs array using a strict equality check.
+ * 
+ * @param oldRef the exact ref object to remove from the refs array.
+ */
+function removeOldRef(oldRef: ToastRef | null) {
+  refs = refs.filter(r => r.current !== oldRef);
+}
+
+export function Toast(props: ToastProps) {
+  const toastRef = React.useRef<ToastRef | null>(null);
+
   return (
     <LoggerProvider enableLogs={false}>
       <ToastRoot
-        ref={(ref: ToastRef) => {
-          refs[nestingLevel] = {
-            current: ref
-          };
+        ref={(ref: ToastRef | null) => {
+          // Since we know there's a ref, we'll update `refs` to use it.
+          if (ref) {
+            // if by chance the ref's object changes, make sure to remove the previous ref object.
+            if (toastRef.current && ref !== toastRef.current) {
+              removeOldRef(toastRef.current);
+            }
+
+            // store the ref in this toast instance to be able to remove it from the array later when the ref becomes null.
+            toastRef.current = ref;
+
+            // add it to the end of the array, which will be used to show the toasts until its ref becomes null.
+            refs.push({
+              current: ref
+            });
+          } else {
+            // remove the this toast's ref, wherever it is in the array.
+            removeOldRef(toastRef.current);
+          }
         }}
-        {...rest}
+        {...props}
       />
     </LoggerProvider>
   );
@@ -58,13 +84,13 @@ export function Toast({ nestingLevel = 0, ...rest }: ToastProps) {
  * Get the active Toast instance `ref`, by priority.
  * The "highest" Toast in the `View` hierarchy has the highest priority.
  *
- * For example, a Toast inside a `Modal`, would have a higher priority than a Toast inside App's Root
- * (which has a default `nestingLevel` of 0)
+ * For example, a Toast inside a `Modal`, would have had its ref set later than a Toast inside App's Root. Therefore, the library knows that it is currently visible on top of the App's Root, and will thus use the `Modal`'s Toast when showing/hiding.
+ *
  * ```js
  * <>
- *  <Toast nestingLevel={0} />
+ *  <Toast />
  *  <Modal>
- *    <Toast nestingLevel={1} />
+ *    <Toast />
  *  </Modal>
  * </>
  * ```

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -41,6 +41,17 @@ type ToastRefObj = {
 let refs: ToastRefObj[] = [];
 
 /**
+ * Adds a ref to the end of the array, which will be used to show the toasts until its ref becomes null.
+ * 
+ * @param newRef the new ref, which must be stable for the life of the Toast instance.
+ */
+function addNewRef(newRef: ToastRef) {
+  refs.push({
+    current: newRef
+  });
+}
+
+/**
  * Removes the passed in ref from the file-level refs array using a strict equality check.
  * 
  * @param oldRef the exact ref object to remove from the refs array.
@@ -61,11 +72,7 @@ export function Toast(props: ToastProps) {
           if (ref) {
             // store the ref in this toast instance to be able to remove it from the array later when the ref becomes null.
             toastRef.current = ref;
-
-            // add it to the end of the array, which will be used to show the toasts until its ref becomes null.
-            refs.push({
-              current: ref
-            });
+            addNewRef(ref);
           } else {
             // remove the this toast's ref, wherever it is in the array.
             removeOldRef(toastRef.current);

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -17,10 +17,16 @@ const ToastRoot = React.forwardRef((props: ToastProps, ref) => {
   });
 
   // This must use useCallback to ensure the ref doesn't get set to null and then a new ref every render.
-  React.useImperativeHandle(ref, React.useCallback(() => ({
-    show,
-    hide
-  }), [hide, show]));
+  React.useImperativeHandle(
+    ref,
+    React.useCallback(
+      () => ({
+        show,
+        hide
+      }),
+      [hide, show]
+    )
+  );
 
   return (
     <ToastUI
@@ -42,7 +48,7 @@ let refs: ToastRefObj[] = [];
 
 /**
  * Adds a ref to the end of the array, which will be used to show the toasts until its ref becomes null.
- * 
+ *
  * @param newRef the new ref, which must be stable for the life of the Toast instance.
  */
 function addNewRef(newRef: ToastRef) {
@@ -53,33 +59,36 @@ function addNewRef(newRef: ToastRef) {
 
 /**
  * Removes the passed in ref from the file-level refs array using a strict equality check.
- * 
+ *
  * @param oldRef the exact ref object to remove from the refs array.
  */
 function removeOldRef(oldRef: ToastRef | null) {
-  refs = refs.filter(r => r.current !== oldRef);
+  refs = refs.filter((r) => r.current !== oldRef);
 }
 
 export function Toast(props: ToastProps) {
   const toastRef = React.useRef<ToastRef | null>(null);
 
+  /*
+    This must use `useCallback` to ensure the ref doesn't get set to null and then a new ref every render.
+    Failure to do so will cause whichever Toast *renders or re-renders* last to be the instance that is used,
+    rather than being the Toast that was *mounted* last.
+  */
+  const setRef = React.useCallback((ref: ToastRef | null) => {
+    // Since we know there's a ref, we'll update `refs` to use it.
+    if (ref) {
+      // store the ref in this toast instance to be able to remove it from the array later when the ref becomes null.
+      toastRef.current = ref;
+      addNewRef(ref);
+    } else {
+      // remove the this toast's ref, wherever it is in the array.
+      removeOldRef(toastRef.current);
+    }
+  }, []);
+
   return (
     <LoggerProvider enableLogs={false}>
-      <ToastRoot
-        // This must use `useCallback` to ensure the ref doesn't get set to null and then a new ref every render. Failure to do so will cause whichever Toast *renders or re-renders* last to be the instance that is used, rather than being the Toast that was *mounted* last.
-        ref={React.useCallback((ref: ToastRef | null) => {
-          // Since we know there's a ref, we'll update `refs` to use it.
-          if (ref) {
-            // store the ref in this toast instance to be able to remove it from the array later when the ref becomes null.
-            toastRef.current = ref;
-            addNewRef(ref);
-          } else {
-            // remove the this toast's ref, wherever it is in the array.
-            removeOldRef(toastRef.current);
-          }
-        }, [])}
-        {...props}
-      />
+      <ToastRoot ref={setRef} {...props} />
     </LoggerProvider>
   );
 }
@@ -88,7 +97,9 @@ export function Toast(props: ToastProps) {
  * Get the active Toast instance `ref`, by priority.
  * The "highest" Toast in the `View` hierarchy has the highest priority.
  *
- * For example, a Toast inside a `Modal`, would have had its ref set later than a Toast inside App's Root. Therefore, the library knows that it is currently visible on top of the App's Root, and will thus use the `Modal`'s Toast when showing/hiding.
+ * For example, a Toast inside a `Modal`, would have had its ref set later than a Toast inside App's Root.
+ * Therefore, the library knows that it is currently visible on top of the App's Root
+ * and will thus use the `Modal`'s Toast when showing/hiding.
  *
  * ```js
  * <>

--- a/src/__tests__/Toast.test.tsx
+++ b/src/__tests__/Toast.test.tsx
@@ -41,7 +41,7 @@ describe('test Toast component', () => {
     expect(onHide).toHaveBeenCalled();
   });
 
-  it('shows Toast inside a Modal (nestingLevel = 1)', async () => {
+  it('shows Toast inside a Modal', async () => {
     const onShow = jest.fn();
     const onHide = jest.fn();
 
@@ -59,7 +59,6 @@ describe('test Toast component', () => {
             <Text>Inside modal</Text>
             <Button title='Hide modal' onPress={() => setIsVisible(false)} />
             <Toast
-              nestingLevel={1}
               onShow={onShowInsideModal}
               onHide={onHideInsideModal}
             />
@@ -135,7 +134,7 @@ describe('test Toast component', () => {
       <>
         <Modal visible={false}>
           <Text>Inside modal</Text>
-          <Toast nestingLevel={1} onShow={onShow} onHide={onHide} />
+          <Toast onShow={onShow} onHide={onHide} />
         </Modal>
       </>
     );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,40 +122,6 @@ export type ToastRef = {
  */
 export type ToastProps = {
   /**
-   * Nesting level for the Toast instance.
-   * The "higher" a Toast instance is in the `View` hierarchy, the bigger its nesting level value.
-   * Default `nestingLevel = 0`.
-   *
-   * By setting this prop, you can show Toasts inside Modals, no matter how nested they would be.
-   *
-   * For example, a Toast inside a `Modal`, would have a bigger `nestingLevel`
-   * than a Toast inside App's Root (which has the default `nestingLevel` of 0).
-   *
-   * ```js
-   * <>
-   *  <Toast />
-   *  <Modal>
-   *    <Toast nestingLevel={1} />
-   *  </Modal>
-   * </>
-   * ```
-   *
-   * If you have nested Modals, the `nestingLevel` prop needs to be adjusted accordingly:
-   *
-   * ```js
-   * <>
-   *  <Toast />
-   *  <Modal>
-   *    <Toast nestingLevel={1} />
-   *    <Modal>
-   *      <Toast nestingLevel={2} />
-   *    </Modal>
-   *  </Modal>
-   * </>
-   * ```
-   */
-  nestingLevel?: number;
-  /**
    * Layout configuration for custom Toast types
    */
   config?: ToastConfig;


### PR DESCRIPTION
Hey @calintamas!

While testing out your latest changes, I was still having issues with the toasts not always showing due to conflicting nesting levels, which can be hard to manage for the user/easily prone to error.

So I got thinking about alternative ways this could work, and I came up with this solution.

It basically makes the assumption that a Toast in a Modal or Native Stack Screen only gets mounted when it's shown. As long as we can keep the ref stable across renders so it doesn't change until the Toast is unmounting (when it sets to null), we can just store them in the array as each one gets added, and remove them as each one unmounts _without any need to have the user control levels at all_.

https://www.dropbox.com/s/sp2sidcq58uagqy/Toast%20Demo%20Using%20Only%20Refs.mp4?dl=0

I recorded the above video showing it working, as well as had comments going throughout the walkthrough (see down below). 

We know the "Demo Inside Modal 1" is re-rendering every 1 second due to the timer/label at the top of the screen. I purposefully did this to test the stability of the ref to make sure one of the other toasts didn't end up becoming the last in the array due to its ref changing after the latest mounted. 

The video proves that a re-render of a Toast on a lower level doesn't cause issues. I did have to solve for this issue by adding the useCallbacks; before I added the useCallbacks, the ref was changing to null and then a new ref every render, which then pushed the bottom level Toasts that re-rendered to be the last in the array. Once I got them stable, the ref is set once per Toast, and it's possible to then just add them/remove them from the array as the ref is set and then unset.

Here's the logging output that matches the video:

```
iOS Running app on iPhone 11
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 1
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 2
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 2
=== filtering out old ref...count after: 1
=== unmounting Toast. refs count is currently: 1
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 2
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 2
=== filtering out old ref...count after: 1
=== unmounting Toast. refs count is currently: 1
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 2
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 3
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 3
=== filtering out old ref...count after: 2
=== unmounting Toast. refs count is currently: 2
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 3
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 3
=== filtering out old ref...count after: 2
=== unmounting Toast. refs count is currently: 2
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 3
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 3
=== filtering out old ref...count after: 2
=== unmounting Toast. refs count is currently: 2
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 2
=== filtering out old ref...count after: 1
=== unmounting Toast. refs count is currently: 1
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 2
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 2
=== filtering out old ref...count after: 1
=== unmounting Toast. refs count is currently: 1
=== in ref handler
=== setting new non-null ref locally.
=== adding ref to refs.
=== mounting new Toast. refs count is currently: 2
=== in ref handler
=== ref was null. removing from refs.
=== filtering out old ref...count before: 2
=== filtering out old ref...count after: 1
=== unmounting Toast. refs count is currently: 1
```

Let me know what you think!

Note: I tried to run tests with `yarn test`, but no matter what I tried, I kept getting this error. What's the trick for running the tests?

<img width="393" alt="Screen Shot 2021-12-05 at 10 25 38 AM" src="https://user-images.githubusercontent.com/5117473/144754743-56d835c4-94bd-482b-b46f-0d44098112b9.png">