### PR TITLE
fix: if autoHide changes from true to false, make sure to clear the timer

### DIFF
--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -77,9 +77,6 @@ export function useToast({ defaultOptions }: UseToastParams) {
         onPress = initialOptions.onPress,
         props = initialOptions.props
       } = params;
-      // TODO: validate input
-      // TODO: use a queue when Toast is already visible
-      setIsVisible(true);
       setData({
         text1,
         text2
@@ -99,6 +96,9 @@ export function useToast({ defaultOptions }: UseToastParams) {
           props
         }) as Required<ToastOptions>
       );
+      // TODO: validate input
+      // TODO: use a queue when Toast is already visible
+      setIsVisible(true);
       onShow();
     },
     [initialOptions, log]

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -106,10 +106,14 @@ export function useToast({ defaultOptions }: UseToastParams) {
 
   React.useEffect(() => {
     const { autoHide } = options;
-    if (isVisible && autoHide) {
-      startTimer();
+    if (isVisible) {
+      if (autoHide) {
+        startTimer();
+      } else {
+        clearTimer();
+      }
     }
-  }, [isVisible, options, startTimer]);
+  }, [isVisible, options, startTimer, clearTimer]);
 
   return {
     isVisible,


### PR DESCRIPTION
I had an issue where showing a toast via a setTimeout with the following conditions would unexpectedly autohide the toast:
- default toast instance is set to autoHide: true
- then present a Modal containing a Toast with one of the default toast instances
- use a setTimeout to delay showing a toast, with autoHide: false
- the toast presented in the modal would still autohide (unexpected).

This code change makes it behave correctly and clear any autohide timer if the value changes.

I tried to write a failing test for the existing code, but couldn't get it to ever fail my expectations. If you have ideas on how to write a test for this one, I'd welcome the help.

Here's a video showing the issue with existing code:

https://user-images.githubusercontent.com/5117473/145053526-b2b4dd64-d691-4e90-8166-1e90f39cad45.mp4

Here's a video showing the resolved issue with the code in this PR:

https://user-images.githubusercontent.com/5117473/145053561-ca1488c0-00ab-42d5-91df-1fa2994ae753.mp4