### PR TITLE
add force push next toast functional

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,18 @@ export type ToastOptions = {
    */
   type?: ToastType;
   /**
+   * Use it when need to force hide current toaster and show next with animation.
+   * Use for overshow toast
+   * Default value: '250' ms
+   */
+  showNextToastAfter?: number;
+  /**
+   * Use it when need to force hide current toaster and show next with animation.
+   * When `true`, the visible Toast force hides and shows a next after showNextToastAfter ms Toast with next props.
+   * Default value: 'false'
+   */
+  forceOverride?: boolean;
+  /**
    * Toast position.
    * Default value: `top`
    */


### PR DESCRIPTION
When the application has some functionality, as in the video - the user presses a button to show a toast with the text of this button. When the button is pressed, the toaster is displayed for a while, and when the user presses another button while the toaster is displayed, the previous toast is not hidden, but only changes the text without animation. We need to hide the previous toast and show the next one with animation.

How it works without a patch
https://drive.google.com/file/d/1ZYm6SfcblQaxDTcLuEHqcsaq_a2bv78i/view?usp=sharing
How it works with a patch
https://drive.google.com/file/d/1bAlti2UUwiriLR1fp0o1inMtCoD7dBrY/view?usp=sharing