### PR TITLE
specify toast types & add toast types enum

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,12 @@ import {
 
 export type ReactChildren = React.ReactNode;
 
-export type ToastType = string;
+export type ToastType = 'success' | 'error' | 'info';
+export enum ToastTypes {
+  success = 'success',
+  error = 'error',
+  info = 'info'
+}
 export type ToastPosition = 'top' | 'bottom';
 
 export type ToastOptions = {

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -2,7 +2,13 @@ import React from 'react';
 
 import { useLogger } from './contexts';
 import { useTimeout } from './hooks';
-import { ToastData, ToastOptions, ToastProps, ToastShowParams } from './types';
+import {
+  ToastData,
+  ToastOptions,
+  ToastProps,
+  ToastShowParams,
+  ToastTypes
+} from './types';
 import { noop } from './utils/func';
 import { mergeIfDefined } from './utils/obj';
 
@@ -12,7 +18,7 @@ export const DEFAULT_DATA: ToastData = {
 };
 
 export const DEFAULT_OPTIONS: Required<ToastOptions> = {
-  type: 'success',
+  type: ToastTypes.success,
   position: 'top',
   autoHide: true,
   visibilityTime: 4000,


### PR DESCRIPTION
# Changes:
- replace `ToastType: string` with `ToastType = 'success' | 'error' | 'info'`
- add `ToastTypes` enum 