### PR TITLE
Modify ToastType to provide intellisense for base toast types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,8 @@ import {
 
 export type ReactChildren = React.ReactNode;
 
-export type ToastType = string;
+type BaseToastType = 'success' | 'error' | 'info';
+export type ToastType = BaseToastType | Omit<string, BaseToastType>;
 export type ToastPosition = 'top' | 'bottom';
 
 export type ToastOptions = {


### PR DESCRIPTION
This is a simple typing change that provides intellisense for the basic toast types provided by the library.

With this change the user can still insert any string he wants but at the same time the editor will propose `success`, `error` and `info` as autocompletion