### PR TITLE
Improved accessibility of text style props for customized toast messages

### DIFF
--- a/src/ToastUI.tsx
+++ b/src/ToastUI.tsx
@@ -35,7 +35,7 @@ function renderComponent({
   show,
   hide
 }: ToastUIProps) {
-  const { text1, text2 } = data;
+  const { text1, text2, text1Style, text2Style } = data;
   const { type, onPress, position, props } = options;
 
   const toastConfig = {
@@ -56,6 +56,8 @@ function renderComponent({
     isVisible,
     text1,
     text2,
+    text1Style,
+    text2Style,
     show,
     hide,
     onPress,

--- a/src/ToastUI.tsx
+++ b/src/ToastUI.tsx
@@ -35,8 +35,8 @@ function renderComponent({
   show,
   hide
 }: ToastUIProps) {
-  const { text1, text2, text1Style, text2Style } = data;
-  const { type, onPress, position, props } = options;
+  const { text1, text2 } = data;
+  const { type, onPress, text1Style, text2Style, position, props } = options;
 
   const toastConfig = {
     ...defaultToastConfig,

--- a/src/__tests__/useToast.test.ts
+++ b/src/__tests__/useToast.test.ts
@@ -119,6 +119,8 @@ describe('test useToast hook', () => {
     const options: ToastOptions = {
       type: 'info',
       position: 'bottom',
+      text1Style: null,
+      text2Style: null,
       autoHide: false,
       visibilityTime: 20,
       topOffset: 120,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,14 @@ export type ToastOptions = {
    */
   type?: ToastType;
   /**
+   * Style for the header text in the Toast (text1).
+   */
+  text1Style?: StyleProp<TextStyle>;
+  /**
+   * Style for the inner message text in the Toast (text2).
+   */
+  text2Style?: StyleProp<TextStyle>;
+  /**
    * Toast position.
    * Default value: `top`
    */
@@ -77,8 +85,6 @@ export type ToastOptions = {
 export type ToastData = {
   text1?: string;
   text2?: string;
-  text1Style?: StyleProp<TextStyle>;
-  text2Style?: StyleProp<TextStyle>;
 };
 
 export type ToastShowParams = ToastData & ToastOptions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,8 @@ export type ToastOptions = {
 export type ToastData = {
   text1?: string;
   text2?: string;
+  text1Style?: StyleProp<TextStyle>;
+  text2Style?: StyleProp<TextStyle>;
 };
 
 export type ToastShowParams = ToastData & ToastOptions;
@@ -108,6 +110,8 @@ export type ToastConfigParams<Props> = {
   isVisible: boolean;
   text1?: string;
   text2?: string;
+  text1Style?: StyleProp<TextStyle>;
+  text2Style?: StyleProp<TextStyle>;
   show: (params: ToastShowParams) => void;
   hide: (params: ToastHideParams) => void;
   onPress: () => void;

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -8,13 +8,13 @@ import { mergeIfDefined } from './utils/obj';
 
 export const DEFAULT_DATA: ToastData = {
   text1: undefined,
-  text2: undefined,
-  text1Style: undefined,
-  text2Style: undefined
+  text2: undefined
 };
 
 export const DEFAULT_OPTIONS: Required<ToastOptions> = {
   type: 'success',
+  text1Style: null,
+  text2Style: null,
   position: 'top',
   autoHide: true,
   visibilityTime: 4000,
@@ -67,9 +67,9 @@ export function useToast({ defaultOptions }: UseToastParams) {
       const {
         text1 = DEFAULT_DATA.text1,
         text2 = DEFAULT_DATA.text2,
-        text1Style = DEFAULT_DATA.text1Style,
-        text2Style = DEFAULT_DATA.text2Style,
         type = initialOptions.type,
+        text1Style = initialOptions.text1Style,
+        text2Style = initialOptions.text2Style,
         position = initialOptions.position,
         autoHide = initialOptions.autoHide,
         visibilityTime = initialOptions.visibilityTime,
@@ -83,13 +83,13 @@ export function useToast({ defaultOptions }: UseToastParams) {
       } = params;
       setData({
         text1,
-        text2,
-        text1Style,
-        text2Style
+        text2
       });
       setOptions(
         mergeIfDefined(initialOptions, {
           type,
+          text1Style,
+          text2Style,
           position,
           autoHide,
           visibilityTime,

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -8,7 +8,9 @@ import { mergeIfDefined } from './utils/obj';
 
 export const DEFAULT_DATA: ToastData = {
   text1: undefined,
-  text2: undefined
+  text2: undefined,
+  text1Style: undefined,
+  text2Style: undefined
 };
 
 export const DEFAULT_OPTIONS: Required<ToastOptions> = {
@@ -65,6 +67,8 @@ export function useToast({ defaultOptions }: UseToastParams) {
       const {
         text1 = DEFAULT_DATA.text1,
         text2 = DEFAULT_DATA.text2,
+        text1Style = DEFAULT_DATA.text1Style,
+        text2Style = DEFAULT_DATA.text2Style,
         type = initialOptions.type,
         position = initialOptions.position,
         autoHide = initialOptions.autoHide,
@@ -79,7 +83,9 @@ export function useToast({ defaultOptions }: UseToastParams) {
       } = params;
       setData({
         text1,
-        text2
+        text2,
+        text1Style,
+        text2Style
       });
       setOptions(
         mergeIfDefined(initialOptions, {


### PR DESCRIPTION
Made modifications to enhance the accessibility of text style props in React Native Toast Message library. The existing implementation caused issues when customizing toast messages in my application, particularly with regard to the text style. To address this, I adjusted the code to ensure that the text-style props are easily accessible and can be modified according to specific requirements. These changes resolve the issues I encountered and provide a smoother experience when customizing toast messages.

closes #478 