### PR TITLE
fix: props sent in show are not passed to the component correctly

### DIFF
--- a/src/ToastUI.tsx
+++ b/src/ToastUI.tsx
@@ -59,7 +59,7 @@ function renderComponent({
     show,
     hide,
     onPress,
-    props
+    ...props
   });
 }
 


### PR DESCRIPTION
If you send any props through the show it is not passed to the component, since it only uses the deconstructed props, inside it does not make any spread.
```
toast.show({
  type: 'success',
  text1: 'Any text',
  props: { AnyProp: 123 }
});
```