### PR TITLE
When the native permission request modal appears, the toast notification also shows up on the screen

### DIFF
--- a/src/components/AnimatedContainer.tsx
+++ b/src/components/AnimatedContainer.tsx
@@ -124,6 +124,7 @@ export function AnimatedContainer({
   }, [animate, isVisible]);
 
   return (
+    isVisible ? 
     <Animated.View
       testID={getTestId('AnimatedContainer')}
       onLayout={computeViewDimensions}
@@ -133,6 +134,7 @@ export function AnimatedContainer({
       pointerEvents={isVisible ? 'box-none' : 'none'}
       {...panResponder.panHandlers}>
       {children}
-    </Animated.View>
+    </Animated.View> :
+    null
   );
 }

--- a/src/components/AnimatedContainer.tsx
+++ b/src/components/AnimatedContainer.tsx
@@ -123,8 +123,9 @@ export function AnimatedContainer({
     animate(newAnimationValue);
   }, [animate, isVisible]);
 
+  if (!isVisible) return (<></>);
+  
   return (
-    isVisible ? 
     <Animated.View
       testID={getTestId('AnimatedContainer')}
       onLayout={computeViewDimensions}
@@ -134,7 +135,6 @@ export function AnimatedContainer({
       pointerEvents={isVisible ? 'box-none' : 'none'}
       {...panResponder.panHandlers}>
       {children}
-    </Animated.View> :
-    null
+    </Animated.View>
   );
 }


### PR DESCRIPTION
Bug Description
Issue:
Whenever a native permission is requested, the toast notification appears at the top of the screen even if it was not triggered previously.

Steps to Reproduce:

1. Have a navigation container in App.js with the v2.1.6 toast positioned at the bottom of the container.
2. Trigger any native Android or iOS permission request.

Expected Behavior:
The toast notification should not appear unless explicitly triggered by the application.

Environment:

- OS: Android
  - Version: 14
  - Device: Samsung Galaxy Note

- OS: iOS
  - Version: 17.5.1
  - Device: iPhone 13 Pro

react-native-toast-message Version: v2.1.6
react-native Version: v0.72.5