### PR TITLE
fix(types): fix types for react 19 compatibility

### DIFF
--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -66,7 +66,7 @@ function removeOldRef(oldRef: ToastRef | null) {
   refs = refs.filter((r) => r.current !== oldRef);
 }
 
-export function Toast(props: ToastProps) {
+export function Toast(props: ToastProps): React.ReactElement {
   const toastRef = React.useRef<ToastRef | null>(null);
 
   /*


### PR DESCRIPTION
PR to fix typing issue with React 19. As Toast does not have children, we can use `ReactElement` instead of the default inferred `JSX.Element`.

Issue: https://github.com/calintamas/react-native-toast-message/issues/571