### PR TITLE
feat: pass ToastShowParams to onShow callback

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,9 +74,9 @@ export type ToastOptions = {
    */
   avoidKeyboard?: boolean;
   /**
-   * Called when Toast is shown
+   * Called when Toast is shown, receives the show params
    */
-  onShow?: () => void;
+  onShow?: (params: ToastShowParams) => void;
   /**
    * Called when Toast hides
    */
@@ -205,9 +205,9 @@ export type ToastProps = {
    */
   avoidKeyboard?: boolean;
   /**
-   * Called when any Toast is shown
+   * Called when any Toast is shown, receives the show params
    */
-  onShow?: () => void;
+  onShow?: (params: ToastShowParams) => void;
   /**
    * Called when any Toast hides
    */

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -116,7 +116,7 @@ export function useToast({ defaultOptions }: UseToastParams) {
       // TODO: validate input
       // TODO: use a queue when Toast is already visible
       setIsVisible(true);
-      onShow();
+      onShow(params);
     },
     [initialOptions, log]
   );


### PR DESCRIPTION
## Summary
- Pass `ToastShowParams` to the `onShow` callback so consumers can access toast data (type, text, props, etc.) when a toast is shown
- Updated type definitions for both `ToastOptions` and `ToastProps`

Closes #587

## Test plan
- [ ] Verify `onShow` callback receives the correct `ToastShowParams` when a toast is shown
- [ ] Verify existing usage without `onShow` params still works (backward compatible)
- [ ] Verify TypeScript types are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)