### PR TITLE
feat: configurable enter/exit animation via animationConfig

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,7 @@ The complete set of **options** is described below:
 | `onHide`         | Called when the Toast hides                                                                                                                                                                     | `() => void`      |               |
 | `onPress`        | Called on Toast press                                                                                                                                                                           | `() => void`      |               |
 | `props`          | Any custom props passed to the specified Toast type. Has effect only when there is a custom Toast type (configured via the `config` prop on the Toast instance) that uses the `props` parameter | `any`             |               |
+| `animationConfig` | Configures the enter/exit animation. See [Animation config](#animation-config) | `ToastAnimationConfig` | `{ type: 'spring', friction: 8 }` |
 
 ### `hide()`
 
@@ -66,6 +67,7 @@ The following set of `props` can be passed to the `Toast` component instance to 
 | `onShow`         | Called when any Toast is shown                                                                                                    | `() => void`                           |               |
 | `onHide`         | Called when any Toast hides                                                                                                       | `() => void`                           |               |
 | `onPress`        | Called on any Toast press                                                                                                         | `() => void`                           |               |
+| `animationConfig` | Default enter/exit animation config applied to every Toast. See [Animation config](#animation-config) | `ToastAnimationConfig` | `{ type: 'spring', friction: 8 }` |
 
 For example, to make sure all your Toasts are displayed at the bottom of the screen:
 
@@ -85,3 +87,37 @@ export function App(props) {
   );
 }
 ```
+
+## Animation config
+
+The enter and exit animations can be customized via the `animationConfig` option. It accepts either a single config (applied to both phases) or a pair `{ enter, exit }`.
+
+Each config has a `type` of `'spring'` or `'timing'` and forwards the rest of the props to `Animated.spring` or `Animated.timing` from React Native (`useNativeDriver` and `toValue` are managed internally).
+
+```js
+import Toast from 'react-native-toast-message';
+import { Easing } from 'react-native';
+
+// timing animation for both enter and exit
+Toast.show({
+  text1: 'Hello',
+  animationConfig: { type: 'timing', duration: 200 }
+});
+
+// different animations for enter and exit
+Toast.show({
+  text1: 'Hello',
+  animationConfig: {
+    enter: { type: 'timing', duration: 200, easing: Easing.out(Easing.cubic) },
+    exit: { type: 'timing', duration: 400, easing: Easing.in(Easing.cubic) }
+  }
+});
+
+// tune the default spring
+Toast.show({
+  text1: 'Hello',
+  animationConfig: { type: 'spring', friction: 6, tension: 40 }
+});
+```
+
+The default is `{ type: 'spring', friction: 8 }`, matching previous releases.

--- a/src/ToastUI.tsx
+++ b/src/ToastUI.tsx
@@ -67,7 +67,15 @@ function renderComponent({
 
 export function ToastUI(props: ToastUIProps) {
   const { isVisible, options, hide } = props;
-  const { position, topOffset, bottomOffset, keyboardOffset, avoidKeyboard, swipeable } = options;
+  const {
+    position,
+    topOffset,
+    bottomOffset,
+    keyboardOffset,
+    avoidKeyboard,
+    swipeable,
+    animationConfig
+  } = options;
 
   return (
     <AnimatedContainer
@@ -78,6 +86,7 @@ export function ToastUI(props: ToastUIProps) {
       keyboardOffset={keyboardOffset}
       avoidKeyboard={avoidKeyboard}
       swipeable={swipeable}
+      animationConfig={animationConfig}
       onHide={hide}>
       {renderComponent(props)}
     </AnimatedContainer>

--- a/src/__tests__/useToast.test.tsx
+++ b/src/__tests__/useToast.test.tsx
@@ -142,7 +142,8 @@ describe('test useToast hook', () => {
       onPress: jest.fn(),
       props: {
         foo: 'bar'
-      }
+      },
+      animationConfig: { type: 'spring', friction: 8 }
     };
     act(() => {
       result.current.show({

--- a/src/components/AnimatedContainer.tsx
+++ b/src/components/AnimatedContainer.tsx
@@ -7,7 +7,7 @@ import {
   useSlideAnimation,
   useViewDimensions
 } from '../hooks';
-import { ReactChildren, ToastPosition } from '../types';
+import { ReactChildren, ToastAnimationConfig, ToastPosition } from '../types';
 import { noop } from '../utils/func';
 import { bound } from '../utils/number';
 import { getTestId } from '../utils/test-id';
@@ -22,6 +22,7 @@ export type AnimatedContainerProps = {
   bottomOffset: number;
   keyboardOffset: number;
   avoidKeyboard: boolean;
+  animationConfig?: ToastAnimationConfig;
   onHide: () => void;
   onRestorePosition?: () => void;
 };
@@ -76,6 +77,7 @@ export function AnimatedContainer({
   bottomOffset,
   keyboardOffset,
   avoidKeyboard,
+  animationConfig,
   onHide,
   onRestorePosition = noop,
   swipeable
@@ -91,7 +93,8 @@ export function AnimatedContainer({
     topOffset,
     bottomOffset,
     keyboardOffset,
-    avoidKeyboard
+    avoidKeyboard,
+    animationConfig
   });
 
   const disable = !swipeable || !isVisible;

--- a/src/hooks/__tests__/useSlideAnimation.test.ts
+++ b/src/hooks/__tests__/useSlideAnimation.test.ts
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 
 import { renderHook } from '@testing-library/react-hooks';
-import { Animated } from 'react-native';
+import { Animated, Easing } from 'react-native';
 
+import { ToastAnimationConfig } from '../../types';
 import {
   translateYOutputRangeFor,
   useSlideAnimation
@@ -15,11 +16,12 @@ const defaultParams = {
   avoidKeyboard: true
 };
 
-const setup = () => {
+const setup = (animationConfig?: ToastAnimationConfig) => {
   const utils = renderHook(() =>
     useSlideAnimation({
       position: 'top',
       height: 20,
+      animationConfig,
       ...defaultParams
     })
   );
@@ -28,7 +30,17 @@ const setup = () => {
   };
 };
 
+const mockAnimation = () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  reset: jest.fn()
+});
+
 describe('test useSlideAnimation hook', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('returns defaults', () => {
     const { result } = setup();
     const { animatedValue, animate, animationStyles } = result.current;
@@ -39,15 +51,83 @@ describe('test useSlideAnimation hook', () => {
     expect(animationStyles.transform).toBeDefined();
   });
 
-  it('animates to a new value', async () => {
-    const spy = jest.spyOn(Animated, 'spring').mockImplementation(() => ({
-      start: jest.fn(),
-      stop: jest.fn(),
-      reset: jest.fn()
-    }));
+  it('uses Animated.spring by default', () => {
+    const springSpy = jest
+      .spyOn(Animated, 'spring')
+      .mockImplementation(mockAnimation);
+    const timingSpy = jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation(mockAnimation);
+
     const { result } = setup();
     result.current.animate(1);
-    expect(spy).toHaveBeenCalled();
+
+    expect(springSpy).toHaveBeenCalled();
+    expect(timingSpy).not.toHaveBeenCalled();
+    expect(springSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ friction: 8, toValue: 1 })
+    );
+  });
+
+  it('uses Animated.timing when animationConfig.type is "timing"', () => {
+    const timingSpy = jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation(mockAnimation);
+
+    const { result } = setup({
+      type: 'timing',
+      duration: 200,
+      easing: Easing.linear
+    });
+    result.current.animate(1);
+
+    expect(timingSpy).toHaveBeenCalled();
+    expect(timingSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        duration: 200,
+        easing: Easing.linear,
+        toValue: 1
+      })
+    );
+  });
+
+  it('forwards spring config (friction, tension) to Animated.spring', () => {
+    const springSpy = jest
+      .spyOn(Animated, 'spring')
+      .mockImplementation(mockAnimation);
+
+    const { result } = setup({ type: 'spring', friction: 6, tension: 40 });
+    result.current.animate(1);
+
+    expect(springSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ friction: 6, tension: 40, toValue: 1 })
+    );
+  });
+
+  it('uses separate configs for enter and exit when provided', () => {
+    const springSpy = jest
+      .spyOn(Animated, 'spring')
+      .mockImplementation(mockAnimation);
+    const timingSpy = jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation(mockAnimation);
+
+    const { result } = setup({
+      enter: { type: 'timing', duration: 150 },
+      exit: { type: 'spring', friction: 12 }
+    });
+
+    result.current.animate(1);
+    expect(timingSpy).toHaveBeenCalledTimes(1);
+    expect(timingSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ duration: 150, toValue: 1 })
+    );
+
+    result.current.animate(0);
+    expect(springSpy).toHaveBeenCalledTimes(1);
+    expect(springSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ friction: 12, toValue: 0 })
+    );
   });
 });
 

--- a/src/hooks/useSlideAnimation.ts
+++ b/src/hooks/useSlideAnimation.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Animated, Platform } from 'react-native';
 
-import { ToastPosition } from '../types';
+import { ToastAnimationConfig, ToastPosition } from '../types';
 import { additiveInverseArray } from '../utils/array';
+import { resolveAnimationConfig } from '../utils/animationConfig';
 import { useKeyboard } from './useKeyboard';
 
 type UseSlideAnimationParams = {
@@ -12,6 +13,7 @@ type UseSlideAnimationParams = {
   bottomOffset: number;
   keyboardOffset: number;
   avoidKeyboard: boolean;
+  animationConfig?: ToastAnimationConfig;
 };
 
 export function translateYOutputRangeFor({
@@ -47,18 +49,34 @@ export function useSlideAnimation({
   topOffset,
   bottomOffset,
   keyboardOffset,
-  avoidKeyboard
+  avoidKeyboard,
+  animationConfig
 }: UseSlideAnimationParams) {
   const animatedValue = React.useRef(new Animated.Value(0));
   const { keyboardHeight } = useKeyboard();
 
   const animate = React.useCallback((toValue: number) => {
-    Animated.spring(animatedValue.current, {
-      toValue,
-      useNativeDriver,
-      friction: 8
-    }).start();
-  }, []);
+    const resolved = resolveAnimationConfig(
+      animationConfig,
+      toValue === 1 ? 'enter' : 'exit'
+    );
+
+    if (resolved.type === 'timing') {
+      const { type: _type, ...timingConfig } = resolved;
+      Animated.timing(animatedValue.current, {
+        ...timingConfig,
+        toValue,
+        useNativeDriver
+      }).start();
+    } else {
+      const { type: _type, ...springConfig } = resolved;
+      Animated.spring(animatedValue.current, {
+        ...springConfig,
+        toValue,
+        useNativeDriver
+      }).start();
+    }
+  }, [animationConfig]);
 
   const translateY = React.useMemo(() => animatedValue.current.interpolate({
     inputRange: [0, 1],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Animated,
   StyleProp,
   TextProps,
   TextStyle,
@@ -12,6 +13,25 @@ export type ReactChildren = React.ReactNode;
 
 export type ToastType = 'success' | 'error' | 'info' | (string & {});
 export type ToastPosition = 'top' | 'bottom';
+
+export type ToastSpringAnimationConfig = {
+  type: 'spring';
+} & Omit<Parameters<typeof Animated.spring>[1], 'useNativeDriver' | 'toValue'>;
+
+export type ToastTimingAnimationConfig = {
+  type: 'timing';
+} & Omit<Parameters<typeof Animated.timing>[1], 'useNativeDriver' | 'toValue'>;
+
+export type ToastSingleAnimationConfig =
+  | ToastSpringAnimationConfig
+  | ToastTimingAnimationConfig;
+
+export type ToastAnimationConfig =
+  | ToastSingleAnimationConfig
+  | {
+      enter?: ToastSingleAnimationConfig;
+      exit?: ToastSingleAnimationConfig;
+    };
 
 export type ToastOptions = {
   /**
@@ -91,6 +111,15 @@ export type ToastOptions = {
    * on the Toast instance) that uses the `props` parameter
    */
   props?: any;
+  /**
+   * Configures the enter/exit animation.
+   *
+   * Pass a single `{ type: 'spring' | 'timing', ...config }` to use the same animation
+   * for both phases, or `{ enter, exit }` to configure them separately.
+   *
+   * Default: `{ type: 'spring', friction: 8 }`
+   */
+  animationConfig?: ToastAnimationConfig;
 };
 
 export type ToastData = {
@@ -216,4 +245,11 @@ export type ToastProps = {
    * Called on any Toast press
    */
   onPress?: () => void;
+  /**
+   * Default enter/exit animation configuration applied to every Toast.
+   * Can be overridden per-call via `Toast.show({ animationConfig })`.
+   *
+   * Default: `{ type: 'spring', friction: 8 }`
+   */
+  animationConfig?: ToastAnimationConfig;
 };

--- a/src/useToast.ts
+++ b/src/useToast.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { useLogger, useGesture } from './contexts';
 import { useTimeout } from './hooks';
 import { ToastData, ToastOptions, ToastProps, ToastShowParams } from './types';
+import { DEFAULT_ANIMATION_CONFIG } from './utils/animationConfig';
 import { noop } from './utils/func';
 import { mergeIfDefined } from './utils/obj';
 
@@ -26,7 +27,8 @@ export const DEFAULT_OPTIONS: Required<ToastOptions> = {
   onShow: noop,
   onHide: noop,
   onPress: noop,
-  props: {}
+  props: {},
+  animationConfig: DEFAULT_ANIMATION_CONFIG
 };
 
 export type UseToastParams = {
@@ -88,7 +90,8 @@ export function useToast({ defaultOptions }: UseToastParams) {
         onHide = initialOptions.onHide,
         onPress = initialOptions.onPress,
         swipeable = initialOptions.swipeable,
-        props = initialOptions.props
+        props = initialOptions.props,
+        animationConfig = initialOptions.animationConfig
       } = params;
       setData({
         text1,
@@ -110,7 +113,8 @@ export function useToast({ defaultOptions }: UseToastParams) {
           onHide,
           onPress,
           swipeable,
-          props
+          props,
+          animationConfig
         }) as Required<ToastOptions>
       );
       // TODO: validate input

--- a/src/utils/__tests__/animationConfig.test.ts
+++ b/src/utils/__tests__/animationConfig.test.ts
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+
+import {
+  DEFAULT_ANIMATION_CONFIG,
+  resolveAnimationConfig
+} from '../animationConfig';
+
+describe('test resolveAnimationConfig function', () => {
+  it('returns the default config when none is provided', () => {
+    expect(resolveAnimationConfig(undefined, 'enter')).toEqual(
+      DEFAULT_ANIMATION_CONFIG
+    );
+    expect(resolveAnimationConfig(undefined, 'exit')).toEqual(
+      DEFAULT_ANIMATION_CONFIG
+    );
+  });
+
+  it('returns a single config for both phases when typed', () => {
+    const config = { type: 'timing', duration: 200 } as const;
+    expect(resolveAnimationConfig(config, 'enter')).toEqual(config);
+    expect(resolveAnimationConfig(config, 'exit')).toEqual(config);
+  });
+
+  it('returns the enter/exit branch when configured separately', () => {
+    const enter = { type: 'timing', duration: 100 } as const;
+    const exit = { type: 'spring', friction: 12 } as const;
+
+    expect(resolveAnimationConfig({ enter, exit }, 'enter')).toEqual(enter);
+    expect(resolveAnimationConfig({ enter, exit }, 'exit')).toEqual(exit);
+  });
+
+  it('falls back to the default when only one phase is configured', () => {
+    const enter = { type: 'timing', duration: 100 } as const;
+    expect(resolveAnimationConfig({ enter }, 'exit')).toEqual(
+      DEFAULT_ANIMATION_CONFIG
+    );
+  });
+});

--- a/src/utils/animationConfig.ts
+++ b/src/utils/animationConfig.ts
@@ -1,0 +1,25 @@
+import {
+  ToastAnimationConfig,
+  ToastSingleAnimationConfig,
+  ToastSpringAnimationConfig
+} from '../types';
+
+export const DEFAULT_ANIMATION_CONFIG: ToastSpringAnimationConfig = {
+  type: 'spring',
+  friction: 8
+};
+
+export type AnimationPhase = 'enter' | 'exit';
+
+export function resolveAnimationConfig(
+  config: ToastAnimationConfig | undefined,
+  phase: AnimationPhase
+): ToastSingleAnimationConfig {
+  if (!config) {
+    return DEFAULT_ANIMATION_CONFIG;
+  }
+  if ('type' in config) {
+    return config;
+  }
+  return config[phase] ?? DEFAULT_ANIMATION_CONFIG;
+}


### PR DESCRIPTION
## Summary

Adds an `animationConfig` option on both `Toast.show()` and the `<Toast />` component so consumers can configure the enter/exit animation (timing or spring, separate enter/exit configs, custom duration/easing/friction/etc).

Closes (or contributes to):
- #550 – AnimationDuration
- #569 – Add configurable dismiss speed for toast animations
- #585 – Add custom animation
- #469 – Variety of animations, or custom animations

A previous attempt at this (#536) was author-closed without review; this PR takes a backward-compatible additive approach instead of switching the default.

## API

```ts
type ToastSpringAnimationConfig = { type: 'spring' } & SpringConfig;
type ToastTimingAnimationConfig = { type: 'timing' } & TimingConfig;

type ToastAnimationConfig =
  | ToastSpringAnimationConfig
  | ToastTimingAnimationConfig
  | { enter?: SingleConfig; exit?: SingleConfig };
```

Usage:

```js
// timing, both phases
Toast.show({ text1: 'Hi', animationConfig: { type: 'timing', duration: 200 } });

// separate enter/exit
Toast.show({
  text1: 'Hi',
  animationConfig: {
    enter: { type: 'timing', duration: 200, easing: Easing.out(Easing.cubic) },
    exit:  { type: 'timing', duration: 400, easing: Easing.in(Easing.cubic) }
  }
});

// tune the default spring
Toast.show({ text1: 'Hi', animationConfig: { type: 'spring', friction: 6 } });
```

## Backward compatibility

**Default is unchanged**: `{ type: 'spring', friction: 8 }`. Existing consumers see no behavior change — the new option is purely additive.

## Implementation

- New types `ToastSpringAnimationConfig` / `ToastTimingAnimationConfig` / `ToastAnimationConfig` in `src/types/index.ts`. Spring/timing props are pulled directly from `Parameters<typeof Animated.spring/timing>[1]` (minus `toValue` / `useNativeDriver`) so they stay in sync with React Native's types.
- New `src/utils/animationConfig.ts` with `resolveAnimationConfig(config, phase)` that returns the config for a given phase, falling back to the default.
- `useSlideAnimation` resolves per call and dispatches to `Animated.spring` or `Animated.timing`.
- `animationConfig` is threaded through `AnimatedContainer` → `ToastUI` → `useToast` and merged in the same flow as other options.

## Tests

- 4 new tests in `useSlideAnimation.test.ts` covering: default spring, opt-in timing, spring config forwarding, separate enter/exit dispatch.
- 4 new tests in `utils/__tests__/animationConfig.test.ts` for the resolver (default, single config, split, partial split).
- 1 existing `useToast` assertion fixture updated to include the new default option.

Result: **83 tests pass** (was 76); `yarn quality` is clean.

## Docs

Added an `animationConfig` row to both tables in `docs/api.md` and an "Animation config" section with three usage examples.